### PR TITLE
Solucionado el fallo al mostrar nombres de usuario en timeline - #43

### DIFF
--- a/youroom/templates/timeline/timeline.html
+++ b/youroom/templates/timeline/timeline.html
@@ -28,7 +28,7 @@
     <div class="pt-sm-3">
         <div class="card">
             <div class="card-header bg-white">
-                {{p.user.username}}
+                {{p.usuario.user.username}}
             </div>
             <div class="container-visor-timeline">
                 <img src="{{p.imagen.url}}" class="card-img-bottom">


### PR DESCRIPTION
Corregida la variable usada en la línea 31 de `timeline.html` para que los nombres de usuario se muestren correctamente en cada tarjeta de publicación.