### PR TITLE
DP: Las publicaciones solo son destacadas por un día - #71

### DIFF
--- a/youroom/publicacion/admin.py
+++ b/youroom/publicacion/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
-from .models import Publicacion, Etiqueta
+from .models import Publicacion, Etiqueta, Destacada
 
 admin.site.register(Publicacion)
 admin.site.register(Etiqueta)
+admin.site.register(Destacada)

--- a/youroom/ranking/admin.py
+++ b/youroom/ranking/admin.py
@@ -1,3 +1,4 @@
 from django.contrib import admin
-
+from .models import Valoracion
+admin.site.register(Valoracion)
 # Register your models here.

--- a/youroom/timeline/views.py
+++ b/youroom/timeline/views.py
@@ -5,6 +5,7 @@ from ranking.forms import ValoracionForm
 from publicacion.enum import Categorias
 from django.utils.decorators import method_decorator
 from django.contrib.auth.decorators import login_required
+from datetime import datetime, timezone
 
 
 @method_decorator(login_required, name='dispatch')
@@ -16,7 +17,11 @@ class TimelineView(TemplateView):
         context = super().get_context_data(**kwargs)
         publicaciones = []
         for destacada in Destacada.objects.all():
-            publicaciones.append(destacada.publicacion)
+            if (datetime.now(timezone.utc) - destacada.fecha_destacada).total_seconds()>86400:
+                destacada.delete()
+            else:
+                publicaciones.append(destacada.publicacion)
+
 
         publicaciones.sort(key=lambda x: x.fecha_publicacion, reverse=True)
 


### PR DESCRIPTION
Ahora los publicaciones destacadas que tengan más de un "día de vida" se eliminan de la clase Destacada, haciendo que no aparezcan con las otras destacadas al principio de la vista de timeline.