### PR TITLE
Correcta visualización del ranking - #75

### DIFF
--- a/youroom/static/css/custom.css
+++ b/youroom/static/css/custom.css
@@ -334,3 +334,10 @@ input[type="file"] {
 .descripcion-usuario {
     font-size: 0.9rem;
 }
+
+@media (max-width: 335px) {
+    .dest,
+    .categs {
+        display: none;
+    }
+}

--- a/youroom/templates/ranking/ranking.html
+++ b/youroom/templates/ranking/ranking.html
@@ -7,7 +7,7 @@
 {% block contenido %}
 <div class="row">
     <div class="col-12">
-        {% for user in usuarios %} 
+        {% for usuario in usuarios %} 
         <div class="card rank-user mb-1 pl-3 pr-3">
             <div class="row pt-2 pb-2">
                 <div class="col-2 col-md-1"><span class="pos">{{forloop.counter}}</span></div>
@@ -20,11 +20,11 @@
                     {% elif forloop.counter == 3 %}
                     <i class="bi bi-trophy-fill tercero"></i>
                     {% endif %}
-                {{user.username}}</div>
+                {{usuario.user.username}}</div>
                 {% else %}
-                <div class="col-7 col-md-8">{{user.username}}</div>
+                <div class="col-7 col-md-8">{{usuario.user.username}}</div>
                 {% endif %}
-                <div class="col-3 text-right valoracion">99</div>
+                <div class="col-3 text-right valoracion">{{usuario.totalPuntos}}</div>
             </div>
         </div>
         {% endfor %}

--- a/youroom/templates/timeline/timeline.html
+++ b/youroom/templates/timeline/timeline.html
@@ -8,13 +8,13 @@
 <ul class="nav justify-content-around opciones-timeline-mobile mb-3 sticky-top">
     <div class="col-6 timeline-nav">
         <li class="nav-item">
-            <a class="nav-link text-white text-center" href="{% url 'timeline' %}"><i class="bi bi-lightning-fill mr-2"></i>Destacados</a>
+            <a class="nav-link text-white text-center" href="{% url 'timeline' %}"><i class="bi bi-lightning-fill dest mr-2"></i>Destacados</a>
         </li>
     </div>
     <div class="col-6 timeline-nav">
         <li class="nav-item dropdown ">
             <a class="nav-link text-white dropdown-toggle text-center" data-toggle="dropdown" href="{% url 'timeline' %}" role="button"
-                aria-haspopup="true" aria-expanded="false"><i class="bi bi-card-list mr-2"></i>Categorías</a>
+                aria-haspopup="true" aria-expanded="false"><i class="bi bi-card-list categs mr-2"></i>Categorías</a>
             <div class="dropdown-menu">
                 {% for categoria in categorias %}
                 <a class="dropdown-item" href="{% url 'timeline_categoria' categoria=categoria.1 %}">{{ categoria.1 }}</a>


### PR DESCRIPTION
La vista de ranking se ha integrado correctamente con el backend. Aquí presento el resultado:
![image](https://user-images.githubusercontent.com/56023983/113344422-585b6f80-9331-11eb-81d4-80c331f3078d.png)

Además, se ha corregido un error de visualización en la vista de timeline por el que los botones de categorías y destacados se descuadraban con pantallas de poco ancho. 

Closes #75 