### PR TITLE
Creación de la vista de error - #83

### DIFF
--- a/youroom/static/css/custom.css
+++ b/youroom/static/css/custom.css
@@ -1,5 +1,6 @@
 @import 'ranking.css';
 @import 'rating.css';
+@import 'error.css';
 
 body {
     background-color: #fafafa;

--- a/youroom/static/css/custom.css
+++ b/youroom/static/css/custom.css
@@ -126,12 +126,6 @@ input[type="file"] {
     padding-right: 1.2rem;
 }
 
-/* .container-pegajoso {
-    position: sticky;
-    top:0px;
-    z-index:100;
-} */
-
 @media (max-width: 767px) {
     .header-mobile {
         background-color: #fff;

--- a/youroom/static/css/error.css
+++ b/youroom/static/css/error.css
@@ -1,0 +1,16 @@
+
+.title-error {
+    color: #099a78;
+    padding: 1rem 0;
+    text-align: center;
+}
+
+.enlace-error {
+    color: #086952;
+}
+
+.enlace-error:hover,
+.enlace-error:active,
+.enlace-error:focus {
+    color: #0ddfad;
+}

--- a/youroom/static/css/error.css
+++ b/youroom/static/css/error.css
@@ -1,16 +1,26 @@
+.error-main {
+    padding: 1.25rem 1rem;
+    margin-top: 0.3rem;
+    text-align: justify;
+}
 
 .title-error {
     color: #099a78;
-    padding: 1rem 0;
     text-align: center;
 }
 
 .enlace-error {
     color: #086952;
+    transition-duration: 0.8s;
 }
 
-.enlace-error:hover,
-.enlace-error:active,
-.enlace-error:focus {
+.enlace-error:hover {
     color: #0ddfad;
+    transition-duration: 0.8s;
+    text-decoration: none;
+}
+
+.boton-error {
+    margin:auto;
+    text-align: center;
 }

--- a/youroom/templates/base/error.html
+++ b/youroom/templates/base/error.html
@@ -6,13 +6,13 @@
 
 {% block contenido %}
 <div class="row">
-    <div class="col-12 text-justify">
-        <h2 class="title-error pt-md-0">Vaya, parece que ha ocurrido un error...</h2>
-        <p class="desc-error">
-            Algo no ha ido como se esperaba por lo que recomendamos que navegue a la página del <a class="enlace-error" href="/timeline/"><strong>Timeline</strong></a>.
-            Vuelva a intentarlo más tarde y, si el error persiste, no dude en contactar con el <a class="enlace-error" href="mailto:soporte.youroom@gmail.com"><strong>equipo de soporte</strong></a>.
+    <div class="error-main card col-12 mt-md-0">
+        <h2 class="title-error pb-2">Vaya, parece que ha ocurrido un error...</h2>
+        <p class="desc-error pb-1">
+            Vuelve a intentarlo más tarde y, si el error persiste, no dudes en contactar con el <a class="enlace-error" href="mailto:soporte.youroom@gmail.com"><strong>equipo de soporte</strong></a>.
+            Muchas gracias, disculpa las molestias.
         </p>
-        <h3 class="title-error">Muchas gracias, disculpe las molestias.</h3>
+        <a type="button" href="/timeline/" class="btn btn-primary boton boton-error"><i class="bi bi-house-fill mr-1"></i> Inicio</a>
     </div>
 </div>
 {% endblock %}

--- a/youroom/templates/base/error.html
+++ b/youroom/templates/base/error.html
@@ -1,0 +1,18 @@
+{% extends 'base/base.html' %}
+{% load l10n %}
+
+{% block titulo_pagina %}Error{% endblock %}
+{% block titulo %}Error{% endblock %}
+
+{% block contenido %}
+<div class="row">
+    <div class="col-12 text-justify">
+        <h2 class="title-error pt-md-0">Vaya, parece que ha ocurrido un error...</h2>
+        <p class="desc-error">
+            Algo no ha ido como se esperaba por lo que recomendamos que navegue a la página del <a class="enlace-error" href="/timeline/"><strong>Timeline</strong></a>.
+            Vuelva a intentarlo más tarde y, si el error persiste, no dude en contactar con el <a class="enlace-error" href="mailto:soporte.youroom@gmail.com"><strong>equipo de soporte</strong></a>.
+        </p>
+        <h3 class="title-error">Muchas gracias, disculpe las molestias.</h3>
+    </div>
+</div>
+{% endblock %}

--- a/youroom/templates/usuario/login.html
+++ b/youroom/templates/usuario/login.html
@@ -6,6 +6,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="shortcut icon" type="image/png" href="{% static 'favicon.ico' %}" />
     <link rel="stylesheet" href="{% static 'css/bootstrap.min.css' %}">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.4.0/font/bootstrap-icons.css">
     <link rel="stylesheet" href="{% static 'css/custom.css' %}">


### PR DESCRIPTION
He creado una vista de error simple para la captura de excepciones, con el siguiente resultado:
![image](https://user-images.githubusercontent.com/56023983/113407265-3bfd1880-93ad-11eb-839f-d8a6105d714a.png)
Funciona de manera responsive y los enlaces tienen los colores propios de la aplicación. He intentando mantener una estética simple, pero cualquier cambio o sugerencia en cuanto al estilo y el contenido es bienvenida.

Además, he añadido el favicon a la pestaña de login.