### PR TITLE
Resolución de fallos de interfaz-#117

### DIFF
--- a/youroom/static/js/publicacion.js
+++ b/youroom/static/js/publicacion.js
@@ -183,3 +183,11 @@ $(document).ready(function(){
         }
     }
 });
+
+$("#btnConfirmarPub").click(function () {
+    $("#btnConfirmarPub").html("<span id=\"spinnerBtn\"></span> Publicando...")
+    $("#spinnerBtn").addClass("spinner-border");
+    $("#spinnerBtn").addClass("spinner-border-sm");
+    $("#spinnerBtn").attr("role", "status");
+    $("#spinnerBtn").attr("aria-hidden", "true");
+});

--- a/youroom/templates/base/base.html
+++ b/youroom/templates/base/base.html
@@ -52,7 +52,7 @@
 
     <div class="container-md align-items-center">
         <div class="row">
-            <div class="col-md-7 mt-md-3 offset-md-1">
+            <div class="col-md-7 mt-3 offset-md-1">
             {% block contenido %}
             {% endblock %}
             </div>

--- a/youroom/templates/perfil/perfil.html
+++ b/youroom/templates/perfil/perfil.html
@@ -64,7 +64,7 @@
                         <div class="col-6">
                             <p class="puntos">{{p.totalValoraciones}} roomies</p>
                         </div>
-                        <div class="col-6 d-flex justify-content-end">
+                        <div class="col-6 align-self-center text-right">
                             <!-- Publicacion destacada -->
                             {% if p.destacada.es_destacada %}
                             <p class="destacada">Destacada</p>

--- a/youroom/templates/publicacion/modalpublicacion.html
+++ b/youroom/templates/publicacion/modalpublicacion.html
@@ -6,7 +6,7 @@
                     <div class="col-12">
                         <p class="text-center">¿Seguro que quieres subir esta publicación?<br>Después no podrás modificarla o eliminarla.</p>
                         <div class="text-center">
-                            <button type="submit" class="btn btn-primary boton">Confirmar</button>
+                            <button id="btnConfirmarPub" type="submit" class="btn btn-primary boton">Confirmar</button>
                             <button type="button" class="btn btn-cancelar-publicacion" data-dismiss="modal">Cancelar</button>
                         </div>
                     </div>


### PR DESCRIPTION
Se han resuelto los siguientes fallos detectados:

- El botón de cerrar sesión, en perfil.html, se ve mal en interfaces móviles.
- Añadir vista de carga al subir publicación ya que es posible que la subida de datos se haga por duplicado.
- La vista de ranking necesita un poco de margen tras el encabezado, al menos en la interfaz de móvil.

Además, se contempla incluir nuevos spinner de procesado en botones, para mostrar tiempos de espera, cuando se implemente el frontend de pagos.

Closes #117 