### PR TITLE
Corregida navegación a tienda - #138

### DIFF
--- a/youroom/templates/perfil/modal_destacado.html
+++ b/youroom/templates/perfil/modal_destacado.html
@@ -4,37 +4,30 @@
             <div class="modal-body">
                 <div class="row">
                     <div class="col-12">
-                        <!-- Modal para destacar publicación -->
                         {% if cont.estaActivo is False %}
-                        <!-- Si es premium -->
                         {% if cont.perfil.totalPuntos >= 50 %}
-                        <!-- Si tiene mas de 50 pts -->
                         <p class="text-center">¿Seguro que quieres destacar la publicación?<br>Perderás el 10% de tus Roomies.</p>
                         <div class="text-center">
                             <a class="btn btn-primary boton" href="{% url 'destacar_publicacion' p.id %}">Sí, quiero destacar la publicación</a>
                             <button type="button" class="btn btn-cancelar-publicacion" data-dismiss="modal">No quiero</button>
                         </div>
                         {% else %}
-                        <!-- Si tiene menos de 50 pts -->
                         <p class="text-center">No puedes destacar la publicación<br>Necesitas al menos 50 Roomies para destacar una publicación.</p>
                         <div class="text-center">
                             <button type="button" class="btn btn-cancelar-publicacion" data-dismiss="modal">Cancelar</button>
                         </div>
                         {% endif %}
                         {% else %}
-                        <!-- Si no es premium -->
                         {% if vidasTotales >= 2 %}
-                        <!-- Tiene 2 vidas o mas -->
                         <p class="text-center">¿Seguro que quieres destacar la publicación?<br>Gastarás 2 Keys priorizando las semanales.</p>
                         <div class="text-center">
                             <a class="btn btn-primary boton" href="{% url 'destacar_publicacion' p.id %}">Sí, quiero destacar la publicación</a>
                             <button type="button" class="btn btn-cancelar-publicacion" data-dismiss="modal">No quiero</button>
                         </div>
                         {% else %}
-                        <!-- Tiene menos de 2 vidas -->
                         <p class="text-center">No puedes destacar la publicación<br>Necesitas al menos 2 Keys para poder destacar la publicación.</p>
                         <div class="text-center">
-                            <a class="btn btn-primary boton" href="#">Quiero comprar Keys</a>
+                            <a class="btn btn-primary boton" href="{% url 'tienda' %}">Quiero comprar Keys</a>
                             <button type="button" class="btn btn-cancelar-publicacion" data-dismiss="modal">Cancelar</button>
                         </div>
                         {% endif %}

--- a/youroom/templates/publicacion/modaletiquetas.html
+++ b/youroom/templates/publicacion/modaletiquetas.html
@@ -6,7 +6,7 @@
                     <div class="col-12">
                         <p id="modalInfoTexto" class="text-center">Has llegado al máximo de etiquetas posibles<br>¡Hazte premium para no tener límites!</p>
                         <div class="text-center">
-                            <a id="modalInfoEnlace" href="#" class="btn btn-primary boton">Hazte premium</a>
+                            <a id="modalInfoEnlace" href="{% url 'tienda' %}" class="btn btn-primary boton">Hazte premium</a>
                             <button type="button" class="btn btn-cancelar-publicacion" data-dismiss="modal">Cancelar</button>
                         </div>
                     </div>

--- a/youroom/templates/publicacion/modalinfo.html
+++ b/youroom/templates/publicacion/modalinfo.html
@@ -6,7 +6,7 @@
                     <div class="col-12">
                         <p id="modalInfoTexto" class="text-center">No tienes suficientes Keys para publicar</p>
                         <div class="text-center">
-                            <a id="modalInfoEnlace" href="#" class="btn btn-primary boton">Comprar Keys</a>
+                            <a id="modalInfoEnlace" href="{% url 'tienda' %}" class="btn btn-primary boton">Comprar Keys</a>
                             <button type="button" class="btn btn-cancelar-publicacion" data-dismiss="modal">Cancelar</button>
                         </div>
                     </div>

--- a/youroom/templates/usuario/registro.html
+++ b/youroom/templates/usuario/registro.html
@@ -16,7 +16,7 @@
 </head>
 <body style="padding-bottom: 0;">
     <div class="container-md container-fluid container-login">
-        <div class="row" style="width: 100%;">
+        <div class="row" style="width: 100%; margin-top: 2rem;">
             <div class="col-12 col-lg-8 offset-lg-2 text-left align-self-center">
                 <div class="reg-form">
                     <form id="form-registro" class="align-self-center" method="post" role="form">{% csrf_token %}


### PR DESCRIPTION
He añadido las URLs necesarias en los modales de publicación y perfil:
- Modal que se despliega al llegar al límite de etiquetas y que indicaba que se navegase a tienda para realizar la suscripción.
- Modal que se despliega al realizar una publicación con "keys" insuficientes y que indicaba que se navegase a tienda para comprar keys.
- Modal que se desplegaba al destacar con "keys" insuficientes y que indicaba que se navegase a tienda para comprar keys.

También he corregido un error de estilo en el formulario de registro por el cual desaparecía parte del mismo cuando se mostraban los errores (esto en vista de móvil).