### PR TITLE
Arreglada incidencia de ver puntuacion-#163

### DIFF
--- a/youroom/publicacion/views.py
+++ b/youroom/publicacion/views.py
@@ -2,6 +2,7 @@ from django.views.generic import FormView, TemplateView
 from django.urls import reverse_lazy
 from .forms import PublicacionForm, ComentarioForm
 from .models import Publicacion, Etiqueta, Destacada, Comentario
+from ranking.models import Valoracion
 from usuario.models import UsuarioPerfil, Premium, ContadorVida
 from django.utils.decorators import method_decorator
 from django.contrib.auth.decorators import login_required
@@ -146,7 +147,6 @@ class ComentarPublicacionView(FormView):
     form_class = ComentarioForm
     template_name = 'publicacion/mostrar.html'
     success_url = reverse_lazy('mostrar_publicacion')
-    pk = None
 
     def form_valid(self, form):
         try:
@@ -183,6 +183,12 @@ class PublicacionMostrarView(TemplateView):
             comentarios = Comentario.objects.filter(publicacion=publicacion)
             context['comentarios'] = comentarios
             context['publicacion'] = publicacion
+            usuario=UsuarioPerfil.objects.get(user=self.request.user)
+            v, creado = Valoracion.objects.get_or_create(usuario=usuario, publicacion=publicacion)
+            if creado:
+                context['valoracion'] = 0
+            else:
+                context['valoracion'] = v.puntuacion
             return context
         except Exception:
             context = {'error_message': 'Ha ocurrido un error inesperado'}

--- a/youroom/templates/publicacion/mostrar.html
+++ b/youroom/templates/publicacion/mostrar.html
@@ -26,15 +26,15 @@
             <div class="row pl-1 bg-white">
                 <form id="v{{publicacion.id}}">{% csrf_token %}
                     <fieldset class="rating">
-                        <input {% if p.1 is 5 %} checked {% endif %} type="radio" id="star5P{{publicacion.id}}" name="valoracionP{{publicacion.id}}" value="5" />
+                        <input {% if valoracion is 5 %} checked {% endif %} type="radio" id="star5P{{publicacion.id}}" name="valoracionP{{publicacion.id}}" value="5" />
                         <label class="full" for="star5P{{publicacion.id}}" title="5 estrellas"></label>
-                        <input {% if p.1 is 4 %} checked {% endif %} type="radio" id="star4P{{publicacion.id}}" name="valoracionP{{publicacion.id}}" value="4" />
+                        <input {% if valoracion is 4 %} checked {% endif %} type="radio" id="star4P{{publicacion.id}}" name="valoracionP{{publicacion.id}}" value="4" />
                         <label class="full" for="star4P{{publicacion.id}}" title="4 estrellas"></label>
-                        <input {% if p.1 is 3 %} checked {% endif %} type="radio" id="star3P{{publicacion.id}}" name="valoracionP{{publicacion.id}}" value="3" />
+                        <input {% if valoracion is 3 %} checked {% endif %} type="radio" id="star3P{{publicacion.id}}" name="valoracionP{{publicacion.id}}" value="3" />
                         <label class="full" for="star3P{{publicacion.id}}" title="3 estrellas"></label>
-                        <input {% if p.1 is 2 %} checked {% endif %} type="radio" id="star2P{{publicacion.id}}" name="valoracionP{{publicacion.id}}" value="2" />
+                        <input {% if valoracion is 2 %} checked {% endif %} type="radio" id="star2P{{publicacion.id}}" name="valoracionP{{publicacion.id}}" value="2" />
                         <label class="full" for="star2P{{publicacion.id}}" title="2 estrellas"></label>
-                        <input {% if p.1 is 1 %} checked {% endif %} type="radio" id="star1P{{publicacion.id}}" name="valoracionP{{publicacion.id}}" value="1" />
+                        <input {% if valoracion is 1 %} checked {% endif %} type="radio" id="star1P{{publicacion.id}}" name="valoracionP{{publicacion.id}}" value="1" />
                         <label class="full" for="star1P{{publicacion.id}}" title="1 estrella"></label>
                     </fieldset>
                 </form>


### PR DESCRIPTION
Se detectó que cuando valorabas e ibas al show de una publicación, no se guardaba la puntuación que le habías dado. Se ha solucionado este error para que se muestre. Se ha cambiado la manera en la que se accedía a este parámetro en la vista ya que no era necesario usar un zip cuando solo hay una publicación.